### PR TITLE
**VIBED** support extensions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -62,19 +62,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
+name = "bitflags"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "clap"
@@ -112,15 +103,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "crossbeam-deque"
@@ -169,6 +160,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,9 +198,9 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
@@ -210,9 +232,8 @@ dependencies = [
  "clap",
  "env_logger",
  "fit_file",
- "geo-types",
- "gpx",
  "log",
+ "quick-xml",
  "rayon",
  "srtm_reader",
  "time",
@@ -225,29 +246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c392291c055671190fc15e037402d8273eafdf73a1eeb1ca5b74fb5babe34a"
 dependencies = [
  "csv",
-]
-
-[[package]]
-name = "geo-types"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
-dependencies = [
- "approx",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "gpx"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfabaf0e8a17a6fb7977fac3bd5846488462edb9f8b246605835483a5501e698"
-dependencies = [
- "geo-types",
- "thiserror",
- "time",
- "xml-rs",
 ]
 
 [[package]]
@@ -264,16 +262,17 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -283,20 +282,14 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "log"
@@ -306,25 +299,15 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
- "libm",
-]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -334,15 +317,15 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -363,10 +346,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.45"
+name = "quick-xml"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -422,19 +414,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde_core"
@@ -470,9 +452,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -481,18 +463,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -531,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -555,9 +537,3 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,11 @@ exclude = ["*.fit"]
 clap = { version = "4.6", features = ["derive", "env"] }
 env_logger = { version = "0.11", features = ["auto-color", "humantime"], default-features = false }
 fit_file = "0.6"
-geo-types = "0.7"
-gpx = "0.10"
 log = "0.4"
 rayon = "1.12"
+quick-xml = "0.41"
 srtm_reader = { version = "0.5", optional = true }
-time = { version = "0.3", default-features = false }
+time = { version = "0.3", default-features = false, features = ["formatting"] }
 
 [features]
 default = ["elevation"]

--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ Yes.
 
 ## Why might this one not be the right choice
 
-[gpx][gpx-crate] lib doesn't support gpx extensions, so neither do we.
-After [this issue](https://github.com/georust/gpx/issues/8) is resolved, this shall be resolved soon.
+GPX export is implemented directly with [`quick-xml`][quick-xml-crate], including common Garmin track-point extensions.
 
 ### it doesn't support strava bulk-export stuff
 
@@ -98,11 +97,11 @@ After [this issue](https://github.com/georust/gpx/issues/8) is resolved, this sh
 <!-- -   [coordinate-altitude](https://github.com/jarjk/coordinate-altitude) -->
 
 -   [fit_file](https://crates.io/crates/fit_file): reading .fit
--   [gpx][gpx-crate]: writing .gpx
+-   [quick-xml][quick-xml-crate]: writing .gpx
 -   [clap](https://crates.io/crates/clap): argument parsing
 -   [rayon](https://crates.io/crates/rayon): multi-threadedness
 -   [srtm](https://github.com/jarjk/srtm_reader): reading elevation data from SRTM [DTM][dtm-wiki] files
 
 [fit2gpx-rs]: https://github.com/jarjk/fit2gpx-rs
-[gpx-crate]: https://crates.io/crates/gpx
+[quick-xml-crate]: https://crates.io/crates/quick-xml
 [dtm-wiki]: https://en.wikipedia.org/wiki/Digital_elevation_model

--- a/src/elevation.rs
+++ b/src/elevation.rs
@@ -1,5 +1,5 @@
+use crate::fit::TrackPoint;
 use crate::{Res, utils};
-use gpx::Waypoint;
 use rayon::prelude::*;
 pub use std::{
     collections::{BTreeSet, HashMap},
@@ -12,14 +12,11 @@ pub type Coord = (i8, i16);
 pub type ElevData = HashMap<Coord, srtm_reader::Tile>;
 
 /// collect all the [`srtm_reader::Tile`]'s [`Coord`]s that shall be loaded into memory
-/// in order to be able to get [`ElevData`] for all [`gpx::Waypoint`]s
+/// in order to be able to get [`ElevData`] for all [`TrackPoint`]s
 #[must_use]
-pub fn needed_tile_coords(wps: &[Waypoint]) -> BTreeSet<Coord> {
-    // kinda Waypoint to Coord
-    let trunc = |wp: &Waypoint| -> Coord {
-        let (x, y) = wp.point().x_y();
-        (y.trunc() as i8, x.trunc() as i16)
-    };
+pub fn needed_tile_coords(wps: &[TrackPoint]) -> BTreeSet<Coord> {
+    // kinda TrackPoint to Coord
+    let trunc = |wp: &TrackPoint| -> Coord { (wp.lat.trunc() as i8, wp.lon.trunc() as i16) };
     // tiles we need
     wps.par_iter()
         .filter(|wp| !utils::is_00(wp))
@@ -92,10 +89,7 @@ impl crate::Fit {
     /// **_NOTE_**: an elevation read from the [`srtm_reader::Tile`] will be applied whether [`Some`] or [`None`]
     pub fn add_elev_loaded(&mut self, elev_data: &ElevData, overwrite: bool) -> Res<()> {
         // coord is (x;y) but we need (y;x)
-        let xy_yx = |wp: &Waypoint| -> srtm_reader::Coord {
-            let (x, y) = wp.point().x_y();
-            (y, x).into()
-        };
+        let xy_yx = |wp: &TrackPoint| -> srtm_reader::Coord { (wp.lat, wp.lon).into() };
         Ok(self
             .track_segment
             .points

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -1,10 +1,27 @@
 use crate::{Res, utils};
 use fit_file::{FitFieldValue, FitRecordMsg, fit_file};
-use geo_types::{Point, coord};
-use gpx::{Gpx, GpxVersion, Track, TrackSegment, Waypoint};
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 use time::OffsetDateTime;
+
+#[derive(Default, Clone)]
+pub struct TrackSegment {
+    pub points: Vec<TrackPoint>,
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct TrackPoint {
+    pub lat: f64,
+    pub lon: f64,
+    pub elevation: Option<f64>,
+    pub time: Option<OffsetDateTime>,
+    pub speed: Option<f64>,
+    pub heart_rate: Option<u8>,
+    pub cadence: Option<u8>,
+    pub temperature: Option<i8>,
+    pub power: Option<u16>,
+    pub distance: Option<f64>,
+}
 
 /// Fit Context structure. An instance of this will be passed to the parser and ultimately to the callback function so we can use it for whatever.
 #[derive(Default, Clone)]
@@ -44,8 +61,7 @@ impl Fit {
         fit_file::read(&mut bufread, Self::callback, &mut fit)?;
 
         fit.track_segment.points.retain(|wp| {
-            let (x, y) = wp.point().x_y();
-            !utils::is_00(wp) && (-90. ..90.).contains(&y) && (-180. ..180.).contains(&x)
+            !utils::is_00(wp) && (-90. ..90.).contains(&wp.lat) && (-180. ..180.).contains(&wp.lon)
         });
         Ok(fit)
     }
@@ -71,15 +87,13 @@ impl Fit {
     /// # Errors
     /// can't write gpx
     pub fn save_to_gpx(self, fname: impl AsRef<Path>) -> Res<()> {
-        let gpx: Gpx = self.into();
-        utils::write_gpx_to_file(gpx, fname)
+        utils::write_gpx_to_file(&self.track_segment.points, fname)
     }
 }
 /// private fns
 impl Fit {
-    /// [`fit_file::FitRecordMsg`] to [`gpx::Waypoint`]
-    // TODO: support heart-rate, distance, temperature and such extensions, if `gpx` crate does too
-    fn frm_to_gwp(frm: FitRecordMsg) -> Waypoint {
+    /// [`fit_file::FitRecordMsg`] to [`TrackPoint`]
+    fn frm_to_gwp(frm: FitRecordMsg) -> TrackPoint {
         let time = frm.timestamp.unwrap_or(0);
         let time = OffsetDateTime::from_unix_timestamp(time.into()).ok();
 
@@ -101,25 +115,24 @@ impl Fit {
             frm.speed.map(Into::into)
         }
         .map(f64::from);
-        // .map(|spd| spd as f64 / 1000. * 3.6); // km/h
+        let heart_rate = frm.heart_rate;
+        let cadence = frm.cadence;
+        let temperature = frm.temperature;
+        let power = frm.power;
+        let distance = frm.distance.map(f64::from);
 
-        // let hr = frm
-        //     .heart_rate
-        //     .map(|hr| hr.checked_add(1))
-        //     .unwrap_or(Some(0))
-        //     .unwrap_or(0);
-
-        // let temp = frm.temperature.unwrap_or(i8::MIN);
-
-        let geo_point = Point(coord! {x: lon, y: lat});
-
-        let mut wp = Waypoint::new(geo_point);
-
-        wp.elevation = alt.map(Into::into);
-        wp.time = time.map(Into::into);
-        wp.speed = speed;
-
-        wp
+        TrackPoint {
+            lat,
+            lon,
+            elevation: alt.map(Into::into),
+            time,
+            speed,
+            heart_rate,
+            cadence,
+            temperature,
+            power,
+            distance,
+        }
     }
     /// Called for each record message as it is being processed.
     fn callback(
@@ -143,20 +156,6 @@ impl Fit {
 
             let wp = Self::frm_to_gwp(msg);
             data.track_segment.points.push(wp);
-        }
-    }
-}
-impl From<Fit> for Gpx {
-    fn from(fit: Fit) -> Self {
-        // Instantiate Gpx struct
-        let track = Track {
-            segments: vec![fit.track_segment],
-            ..Track::default()
-        };
-        Self {
-            version: GpxVersion::Gpx11,
-            tracks: vec![track],
-            ..Self::default()
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,24 +1,116 @@
-use gpx::{Gpx, Waypoint};
+use crate::fit::TrackPoint;
+use quick_xml::Writer;
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use std::io::Write;
 use std::{fs::File, io::BufWriter, path::Path};
+use time::format_description::well_known::Rfc3339;
 
-/// write the `gpx` to `fname`
+/// write the `points` to `fname` as gpx
 /// # Errors
 /// can't write
-pub fn write_gpx_to_file(gpx: Gpx, fname: impl AsRef<Path>) -> crate::Res<()> {
+pub fn write_gpx_to_file(points: &[TrackPoint], fname: impl AsRef<Path>) -> crate::Res<()> {
     // Create file at `fname`
     let gpx_file = File::create(fname.as_ref())?;
     let bufw = BufWriter::new(gpx_file);
+    let mut writer = Writer::new_with_indent(bufw, b' ', 2);
 
     // Write to file
-    gpx::write(&gpx, bufw)?;
+    writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))?;
+
+    let mut gpx = BytesStart::new("gpx");
+    gpx.push_attribute(("version", "1.1"));
+    gpx.push_attribute(("creator", "fit2gpx"));
+    gpx.push_attribute(("xmlns", "http://www.topografix.com/GPX/1/1"));
+    gpx.push_attribute((
+        "xmlns:gpxtpx",
+        "http://www.garmin.com/xmlschemas/TrackPointExtension/v1",
+    ));
+    gpx.push_attribute(("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"));
+    gpx.push_attribute((
+        "xsi:schemaLocation",
+        "http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd",
+    ));
+    writer.write_event(Event::Start(gpx))?;
+
+    writer.write_event(Event::Start(BytesStart::new("trk")))?;
+    writer.write_event(Event::Start(BytesStart::new("trkseg")))?;
+
+    for point in points {
+        write_track_point(&mut writer, point)?;
+    }
+
+    writer.write_event(Event::End(BytesEnd::new("trkseg")))?;
+    writer.write_event(Event::End(BytesEnd::new("trk")))?;
+    writer.write_event(Event::End(BytesEnd::new("gpx")))?;
+    writer.get_mut().flush()?;
+
     log::debug!("written {:?}", fname.as_ref());
     Ok(())
 }
 /// is this `wp` null(0; 0)?
-pub fn is_00(wp: &Waypoint) -> bool {
-    let res = wp.point().x_y() == (0., 0.);
+pub fn is_00(wp: &TrackPoint) -> bool {
+    let res = (wp.lon, wp.lat) == (0., 0.);
     if res {
         log::trace!("{wp:?} is null");
     }
     res
+}
+
+fn write_track_point<W: Write>(writer: &mut Writer<W>, point: &TrackPoint) -> crate::Res<()> {
+    let lat = point.lat.to_string();
+    let lon = point.lon.to_string();
+
+    let mut trkpt = BytesStart::new("trkpt");
+    trkpt.push_attribute(("lat", lat.as_str()));
+    trkpt.push_attribute(("lon", lon.as_str()));
+    writer.write_event(Event::Start(trkpt))?;
+
+    if let Some(elevation) = point.elevation {
+        write_text_element(writer, "ele", &elevation.to_string())?;
+    }
+    if let Some(time) = point.time {
+        write_text_element(writer, "time", &time.format(&Rfc3339)?)?;
+    }
+    if let Some(speed) = point.speed {
+        write_text_element(writer, "speed", &speed.to_string())?;
+    }
+
+    if point.heart_rate.is_some()
+        || point.cadence.is_some()
+        || point.temperature.is_some()
+        || point.power.is_some()
+        || point.distance.is_some()
+    {
+        writer.write_event(Event::Start(BytesStart::new("extensions")))?;
+        writer.write_event(Event::Start(BytesStart::new("gpxtpx:TrackPointExtension")))?;
+
+        if let Some(hr) = point.heart_rate {
+            write_text_element(writer, "gpxtpx:hr", &hr.to_string())?;
+        }
+        if let Some(cad) = point.cadence {
+            write_text_element(writer, "gpxtpx:cad", &cad.to_string())?;
+        }
+        if let Some(temp) = point.temperature {
+            write_text_element(writer, "gpxtpx:atemp", &temp.to_string())?;
+        }
+        if let Some(power) = point.power {
+            write_text_element(writer, "gpxtpx:power", &power.to_string())?;
+        }
+        if let Some(distance) = point.distance {
+            write_text_element(writer, "gpxtpx:distance", &distance.to_string())?;
+        }
+
+        writer.write_event(Event::End(BytesEnd::new("gpxtpx:TrackPointExtension")))?;
+        writer.write_event(Event::End(BytesEnd::new("extensions")))?;
+    }
+
+    writer.write_event(Event::End(BytesEnd::new("trkpt")))?;
+    Ok(())
+}
+
+fn write_text_element<W: Write>(writer: &mut Writer<W>, name: &str, value: &str) -> crate::Res<()> {
+    writer.write_event(Event::Start(BytesStart::new(name)))?;
+    writer.write_event(Event::Text(BytesText::new(value)))?;
+    writer.write_event(Event::End(BytesEnd::new(name)))?;
+    Ok(())
 }


### PR DESCRIPTION
yet to be completed properly...

---

- opencode, gpt-5.3-codex

> prompt: add support for writing heart-rate and other common extensions by leaving the gpx crate and manually exporting via `quick-xml`

## output

Implemented: GPX writing now bypasses gpx crate and uses quick-xml directly, including Garmin trackpoint extensions (heart rate + other common fields).
- Replaced gpx::Waypoint/TrackSegment/Gpx usage with internal data structs in src/fit.rs:
- Added TrackPoint + TrackSegment models.
- Fit::save_to_gpx now writes TrackPoints directly.
- FIT record parsing now captures extension-friendly fields: heart_rate, cadence, temperature, power, distance, plus speed/time/elevation/lat/lon.
- Rewrote GPX output pipeline in src/utils.rs using quick-xml:
- Emits GPX 1.1 with namespaces and schema location.
- Writes <trk>/<trkseg>/<trkpt> manually.
- Writes <extensions><gpxtpx:TrackPointExtension>... when extension values exist.
- Extension tags currently emitted: gpxtpx:hr, gpxtpx:cad, gpxtpx:atemp, gpxtpx:power, gpxtpx:distance.
- Updated elevation integration to use the new point type in src/elevation.rs (no gpx::Waypoint dependency).
- Updated dependencies in Cargo.toml:
- removed gpx and geo-types
- added quick-xml
- enabled time formatting feature for RFC3339 timestamps.
- Updated README dependency/limitations text in README.md to reflect direct XML export and extension support.
Validation done:
- Ran cargo fmt
- Ran cargo check successfully
If you want, next I can:
1. Add gpxtpx:speed inside extensions too (some consumers prefer it there),
2. Add a tiny regression test that asserts extension tags are present in written GPX,
3. Normalize float formatting for cleaner/stable XML output.
